### PR TITLE
Remove the svg component when calculations are done.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,24 +3,21 @@ import memoize from 'lodash.memoize';
 const MEASUREMENT_ELEMENT_ID = '__react_svg_text_measurement_id';
 
 function getStringWidth(str, style) {
-  try {
-    // Calculate length of each word to be used to determine number of words per line
-    let textEl = document.getElementById(MEASUREMENT_ELEMENT_ID);
-    if (!textEl) {
-      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-      textEl = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-      textEl.setAttribute('id', MEASUREMENT_ELEMENT_ID);
-      svg.appendChild(textEl);
-      document.body.appendChild(svg);
-    }
+  let svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  let textElement = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+  textElement.setAttribute('id', MEASUREMENT_ELEMENT_ID);
+  svg.appendChild(textElement);
+  document
+      .body
+      .appendChild(svg);
 
-    Object.assign(textEl.style, style);
-    textEl.textContent = str;
-    return textEl.getComputedTextLength();
-  } catch (e) {
-    return null;
-  }
+  Object.assign(textElement.style, style);
+  textElement.textContent = str;
+  let ret = textElement.getComputedTextLength()
+  document.body.removeChild(svg);
+  return ret;
 }
+
 const getStringWidthMemoized = memoize(getStringWidth);
 
 export { getStringWidthMemoized as getStringWidth }


### PR DESCRIPTION
I had a problem where the SVG used for measuring would take up space at the bottom of my document. To fix this I have changed the code to delete the elements when the measurement is done.